### PR TITLE
Get form within scope

### DIFF
--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -280,24 +280,24 @@ angular
       return isFieldValid;
     } // validate()
 
-	//----
-	// Private functions declaration
-	//----------------------------------
-	
-	/** Get form within scope (if found)
+    //----
+    // Private functions declaration
+    //----------------------------------
+    
+    /** Get form within scope (if found)
     * @param self
     */
-	function getScopeForm(self) {
-	  var forms = document.querySelectorAll('form');
-	  for (var i = 0; i < forms.length; i++) {
-	    var form = document.querySelectorAll('form')[i];
-	    if (form && form.name && self.scope[form.name]) {
-	      return self.scope[form.name];
-	    }
-	  }
-	  return null;
-	}
-	
+    function getScopeForm(self) {
+      var forms = document.querySelectorAll('form');
+      for (var i = 0; i < forms.length; i++) {
+        var form = document.querySelectorAll('form')[i];
+        if (form && form.name && self.scope[form.name]) {
+          return self.scope[form.name];
+        }
+      }
+      return null;
+    }
+    
     /** Add the error to the validation summary
      * @param self
      * @param string elmName: element name (name attribute)
@@ -323,10 +323,10 @@ angular
 
       // save validation summary 2 variable locations, inside the scope object and also in the form object (if found)
       self.scope.$validationSummary = validationSummary;
-	  var form = getScopeForm(self);
-	  if (form) {
-	    form.$validationSummary = validationSummary;
-	  }
+      var form = getScopeForm(self);
+      if (form) {
+        form.$validationSummary = validationSummary;
+      }
     }
 
     /** Quick function to find an object inside an array by it's given field name and value, return the index found or -1

--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -283,7 +283,20 @@ angular
 	  //----
 		// Private functions declaration
 		//----------------------------------
-
+	/** Get form within scope (if found)
+    * @param self
+    */
+	function getScopeForm(self) {
+	    var forms = document.querySelectorAll('form');
+	    for (var i = 0; i < forms.length; i++) {
+	        var form = document.querySelectorAll('form')[i];
+	        if (form && form.name && self.scope[form.name]) {
+	            return self.scope[form.name];
+	        }
+	    }
+	    return null;
+	}
+	
     /** Add the error to the validation summary
      * @param self
      * @param string elmName: element name (name attribute)
@@ -309,10 +322,10 @@ angular
 
       // save validation summary 2 variable locations, inside the scope object and also in the form object (if found)
       self.scope.$validationSummary = validationSummary;
-      var formName = angular.element(document.querySelector('form')).attr('name');
-      if(!!formName) {
-        self.scope[formName].$validationSummary = validationSummary;
-      }
+	  var form = getScopeForm(self);
+	  if (form) {
+	    form.$validationSummary = validationSummary;
+	  }
     }
 
     /** Quick function to find an object inside an array by it's given field name and value, return the index found or -1

--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -280,21 +280,22 @@ angular
       return isFieldValid;
     } // validate()
 
-	  //----
-		// Private functions declaration
-		//----------------------------------
+	//----
+	// Private functions declaration
+	//----------------------------------
+	
 	/** Get form within scope (if found)
     * @param self
     */
 	function getScopeForm(self) {
-	    var forms = document.querySelectorAll('form');
-	    for (var i = 0; i < forms.length; i++) {
-	        var form = document.querySelectorAll('form')[i];
-	        if (form && form.name && self.scope[form.name]) {
-	            return self.scope[form.name];
-	        }
+	  var forms = document.querySelectorAll('form');
+	  for (var i = 0; i < forms.length; i++) {
+	    var form = document.querySelectorAll('form')[i];
+	    if (form && form.name && self.scope[form.name]) {
+	      return self.scope[form.name];
 	    }
-	    return null;
+	  }
+	  return null;
 	}
 	
     /** Add the error to the validation summary


### PR DESCRIPTION
Previous code retrieved first form on page, and exited if that form did not have a name.
This change will let it get first form with a name within scope.
Needed if, like in my case, there are several nameless forms on the page that are out of my control and out of scope.