### PR TITLE
Extend directives for revalidating

### DIFF
--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -482,7 +482,7 @@ angular
       var isSubmitted = (!!attrs && attrs.isSubmitted) ? attrs.isSubmitted : false;
 
       // invalid & isDirty, display the error message... if <span> not exist then create it, else udpate the <span> text
-      if (!_globalOptions.hideErrorUnderInputs && !!attrs && !attrs.isValid && (isSubmitted || self.ctrl.$dirty || self.ctrl.$touched)) {
+      if (!_globalOptions.hideErrorUnderInputs && !!attrs && !attrs.isValid && (isSubmitted || self.ctrl.$dirty || self.ctrl.$touched || self.ctrl.revalidateCalled)) {
         (errorElm.length > 0) ? errorElm.html(errorMsg) : elm.after('<div class="validation validation-' + elmInputName + ' text-danger">' + errorMsg + '</div>');
       } else {
         errorElm.html('');  // element is pristine or no validation applied, error message has to be blank

--- a/src/validation-directive.js
+++ b/src/validation-directive.js
@@ -97,7 +97,7 @@
 
               if (!elm.isValidationCancelled) {
               // attempt to validate & run validation callback if user requested it
-              var validationPromise = attemptToValidate(value, 0);
+              var validationPromise = attemptToValidate(value);
               if(!!_validationCallback) {
                 commonObj.runValidationCallbackOnPromise(validationPromise, _validationCallback);
               }

--- a/src/validation-directive.js
+++ b/src/validation-directive.js
@@ -87,6 +87,26 @@
 
         // attach the onBlur event handler on the element
         elm.bind('blur', blurHandler);
+		
+		 // attach the angularValidation.revalidate event handler on the scope
+        scope.$on('angularValidation.revalidate', function(event, args){
+          if (args == ctrl.$name)
+          {
+              ctrl.revalidateCalled = true;
+              var value = ctrl.$modelValue;
+
+              if (!elm.isValidationCancelled) {
+              // attempt to validate & run validation callback if user requested it
+              var validationPromise = attemptToValidate(value, 0);
+              if(!!_validationCallback) {
+                commonObj.runValidationCallbackOnPromise(validationPromise, _validationCallback);
+              }
+            }
+            else {
+              ctrl.$setValidity('validation', true);
+            }
+          }
+        });
 
         //----
         // Private functions declaration


### PR DESCRIPTION
Extending the package make a revalidation possible for directives.

Example: http://plnkr.co/edit/o1fftbnmRfjScEDmi7ZH?p=preview

Created from Issue: https://github.com/ghiscoding/angular-validation/issues/102