### PR TITLE
Fix revalidate for directive

### DIFF
--- a/src/validation-directive.js
+++ b/src/validation-directive.js
@@ -100,7 +100,8 @@
             ctrl.revalidateCalled = true;
             var value = ctrl.$modelValue;
 
-            if (!!elm && elm.hasOwnProperty("isValidationCancelled")) {
+            var formElmObj = commonObj.getFormElementByName(ctrl.$name);
+            if (!!formElmObj && formElmObj.hasOwnProperty("isValidationCancelled")) {
               // attempt to validate & run validation callback if user requested it
               var validationPromise = attemptToValidate(value);
               if(!!_validationCallback) {


### PR DESCRIPTION
This is related to issue #150. 

ctrl.hasOwnProperty("isValidationCancelled") never seems to evaluate to true. Got the idea for this fix from the blur handler.