### PR TITLE
fix reference error

### DIFF
--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -816,7 +816,7 @@ angular
       var formName = (!!formObj) ? formObj.getAttribute("name") : null;
 
       if (!!formObj && !!formName) {
-        parentForm = (!!_globalOptions && !!_globalOptions.controllerAs && formName.indexOf('.') >= 0)
+        var parentForm = (!!_globalOptions && !!_globalOptions.controllerAs && formName.indexOf('.') >= 0)
           ? objectFindById(self.scope, formName, '.')
           : self.scope[formName];
 


### PR DESCRIPTION
The "parentForm" variable is not initialized therefore leads to:

```
ReferenceError: parentForm is not defined
```