### PR TITLE
fix Cannot read property 'indexOf' of undefined

### DIFF
--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -178,7 +178,7 @@ angular
       self = analyzeElementAttributes(self);
 
       // get the rules(or validation), inside directive it's named (validation), inside service(rules)
-      var rules = self.validatorAttrs.hasOwnProperty('rules') ? self.validatorAttrs.rules : self.validatorAttrs.validation;
+      var rules = self.validatorAttrs.rules || self.validatorAttrs.validation || '';
 
       // We first need to see if the validation holds a custom user regex, if it does then deal with it first
       // So why deal with it separately? Because a Regex might hold pipe '|' and so we don't want to mix it with our regular validation pipe

--- a/src/validation-common.js
+++ b/src/validation-common.js
@@ -178,7 +178,7 @@ angular
       self = analyzeElementAttributes(self);
 
       // get the rules(or validation), inside directive it's named (validation), inside service(rules)
-      var rules = self.validatorAttrs.rules || self.validatorAttrs.validation;
+      var rules = self.validatorAttrs.hasOwnProperty('rules') ? self.validatorAttrs.rules : self.validatorAttrs.validation;
 
       // We first need to see if the validation holds a custom user regex, if it does then deal with it first
       // So why deal with it separately? Because a Regex might hold pipe '|' and so we don't want to mix it with our regular validation pipe


### PR DESCRIPTION
The `.rules` property could be an empty string in which case the code dies because it uses `self.validatorAttrs.validation` which could be undefined, therefore the `.indexOf` check fails.
This fixes TypeError: Cannot read property 'indexOf' of undefined.